### PR TITLE
Add reminder functionality

### DIFF
--- a/src/main/java/Parser.java
+++ b/src/main/java/Parser.java
@@ -55,6 +55,10 @@ public class Parser {
             return parseFindCommand(cmd);
         }
 
+        if (cmd.equals("remind") || cmd.startsWith("remind ")) {
+            return parseRemindCommand(cmd);
+        }
+
         throw new UnknownCommandException("I don't understand that command! Please try again.");
     }
 
@@ -171,5 +175,26 @@ public class Parser {
             throw new InvalidParameterException("Please specify a keyword to search for!");
         }
         return new FindCommand(keyword);
+    }
+
+    private static Command parseRemindCommand(String cmd) throws InvalidParameterException {
+        if (cmd.equals("remind")) {
+            return new RemindCommand();
+        }
+
+        String daysText = cmd.substring(7).trim();
+        if (daysText.isEmpty()) {
+            throw new InvalidParameterException("Please specify the number of days as a positive integer!");
+        }
+
+        try {
+            int days = Integer.parseInt(daysText);
+            if (days <= 0) {
+                throw new InvalidParameterException("Please specify the number of days as a positive integer!");
+            }
+            return new RemindCommand(days);
+        } catch (NumberFormatException e) {
+            throw new InvalidParameterException("Please specify the number of days as a positive integer!");
+        }
     }
 }

--- a/src/main/java/commands/RemindCommand.java
+++ b/src/main/java/commands/RemindCommand.java
@@ -1,0 +1,123 @@
+package commands;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import tasks.Deadline;
+import tasks.Event;
+import tasks.Task;
+import tasks.TaskList;
+import ui.Ui;
+import exceptions.SixException;
+
+/**
+ * Command to show reminders about upcoming tasks.
+ * Displays deadlines and events that are due within a specified number of days.
+ */
+public class RemindCommand extends Command {
+    private int days;
+
+    /**
+     * Creates a new RemindCommand with the default reminder period of 7 days.
+     */
+    public RemindCommand() {
+        this.days = 7;
+    }
+
+    /**
+     * Creates a new RemindCommand with a specified reminder period.
+     *
+     * @param days The number of days to look ahead for reminders.
+     */
+    public RemindCommand(int days) {
+        this.days = days;
+    }
+
+    @Override
+    public void execute(TaskList tasks, Ui ui) throws SixException {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.plusDays(days);
+
+        List<Task> upcomingDeadlines = new ArrayList<>();
+        List<Task> upcomingEvents = new ArrayList<>();
+
+        for (Task task : tasks.getTasks()) {
+            if (task.isDone()) {
+                continue; // Skip completed tasks
+            }
+
+            if (task instanceof Deadline) {
+                Deadline deadline = (Deadline) task;
+                LocalDateTime by = deadline.getBy();
+                if (by != null && !by.isBefore(now) && !by.isAfter(threshold)) {
+                    upcomingDeadlines.add(task);
+                }
+            } else if (task instanceof Event) {
+                Event event = (Event) task;
+                LocalDateTime from = event.getFrom();
+                if (from != null && !from.isBefore(now) && !from.isAfter(threshold)) {
+                    upcomingEvents.add(task);
+                }
+            }
+        }
+
+        // Sort by date/time
+        upcomingDeadlines.sort(Comparator.comparing(t -> ((Deadline) t).getBy()));
+        upcomingEvents.sort(Comparator.comparing(t -> ((Event) t).getFrom()));
+
+        StringBuilder message = new StringBuilder();
+        message.append("📅 Reminders for the next ").append(days).append(" day(s):\n");
+
+        if (upcomingDeadlines.isEmpty() && upcomingEvents.isEmpty()) {
+            message.append("   No upcoming deadlines or events!");
+        } else {
+            if (!upcomingDeadlines.isEmpty()) {
+                message.append("\n   🔔 Upcoming Deadlines:\n");
+                for (Task task : upcomingDeadlines) {
+                    Deadline deadline = (Deadline) task;
+                    long daysUntil = ChronoUnit.DAYS.between(now, deadline.getBy());
+                    long hoursUntil = ChronoUnit.HOURS.between(now, deadline.getBy()) % 24;
+                    String timeLeft = formatTimeLeft(daysUntil, hoursUntil);
+                    message.append("     • ").append(task.toString()).append("\n");
+                    message.append("       ⏰ Due in: ").append(timeLeft).append("\n");
+                }
+            }
+
+            if (!upcomingEvents.isEmpty()) {
+                message.append("\n   📆 Upcoming Events:\n");
+                for (Task task : upcomingEvents) {
+                    Event event = (Event) task;
+                    long daysUntil = ChronoUnit.DAYS.between(now, event.getFrom());
+                    long hoursUntil = ChronoUnit.HOURS.between(now, event.getFrom()) % 24;
+                    String timeLeft = formatTimeLeft(daysUntil, hoursUntil);
+                    message.append("     • ").append(task.toString()).append("\n");
+                    message.append("       ⏰ Starts in: ").append(timeLeft).append("\n");
+                }
+            }
+        }
+
+        ui.showMessage(message.toString());
+    }
+
+    /**
+     * Formats the time left into a human-readable string.
+     *
+     * @param days  The number of days left.
+     * @param hours The number of hours left.
+     * @return A formatted string representing the time left.
+     */
+    private String formatTimeLeft(long days, long hours) {
+        if (days == 0 && hours == 0) {
+            return "Less than an hour";
+        } else if (days == 0) {
+            return hours + " hour" + (hours != 1 ? "s" : "");
+        } else if (hours == 0) {
+            return days + " day" + (days != 1 ? "s" : "");
+        } else {
+            return days + " day" + (days != 1 ? "s" : "") + " and " + hours + " hour" + (hours != 1 ? "s" : "");
+        }
+    }
+}

--- a/src/test/java/ParserTest.java
+++ b/src/test/java/ParserTest.java
@@ -167,4 +167,31 @@ public class ParserTest {
         Command result = Parser.parse("mark    5");
         assertTrue(result instanceof MarkCommand);
     }
+
+    @Test
+    public void parse_remindCommandWithoutDays_returnsRemindCommand() throws SixException {
+        Command result = Parser.parse("remind");
+        assertTrue(result instanceof RemindCommand);
+    }
+
+    @Test
+    public void parse_remindCommandWithValidDays_returnsRemindCommand() throws SixException {
+        Command result = Parser.parse("remind 3");
+        assertTrue(result instanceof RemindCommand);
+    }
+
+    @Test
+    public void parse_remindCommandWithZeroDays_throwsInvalidParameterException() {
+        assertThrows(InvalidParameterException.class, () -> Parser.parse("remind 0"));
+    }
+
+    @Test
+    public void parse_remindCommandWithNegativeDays_throwsInvalidParameterException() {
+        assertThrows(InvalidParameterException.class, () -> Parser.parse("remind -2"));
+    }
+
+    @Test
+    public void parse_remindCommandWithNonInteger_throwsInvalidParameterException() {
+        assertThrows(InvalidParameterException.class, () -> Parser.parse("remind tomorrow"));
+    }
 }


### PR DESCRIPTION
Add remind command for upcoming tasks

Users currently have no way to proactively check what deadlines and events are coming up, making it easy to miss important tasks.

Introduce a new remind command that scans all tasks and displays upcoming deadlines/events within a configurable time window. The command supports a default range and an optional day argument, skips completed tasks, sorts results by time, and shows clear time-left information.

Integrate the feature end-to-end by wiring command parsing, validating user input, and adding parser tests for valid and invalid remind usages so reminder behavior is reliable.